### PR TITLE
Feat: Implement reactive math module for standard algebraic functions (#7)

### DIFF
--- a/src/pypagate/__init__.py
+++ b/src/pypagate/__init__.py
@@ -132,12 +132,15 @@ class Formula:
         return self._value
 
     def __str__(self):
-        global __bin_str_map
-        global __unary_str_map
+        # Bypass Python's name mangling by directly accessing the runtime globals
         if not self.bin_op:
-            return __unary_str_map[self.unary_op] + " (" + str(self._rhs) + ")"
-        return f"({str(self._lhs)}) {__bin_str_map[self.bin_op]} ({str(self._rhs)})"
-
+            unary_map = globals().get("__unary_str_map", {})
+            op_name = unary_map.get(self.unary_op, getattr(self.unary_op, "__name__", "op"))
+            return op_name + " (" + str(self._rhs) + ")"
+            
+        bin_map = globals().get("__bin_str_map", {})
+        return f"({str(self._lhs)}) {bin_map.get(self.bin_op, 'op')} ({str(self._rhs)})"    
+    
     # Binary operations
     __add__ = _register_bin_op(operator.add)
     __radd__ = _register_rbin_op(operator.add)

--- a/src/pypagate/math.py
+++ b/src/pypagate/math.py
@@ -1,0 +1,28 @@
+import math as _math
+from numbers import Number
+from pypagate import Formula, Term
+
+def _reactive_unary(func):
+    """Wraps standard math functions to return reactive Formulas."""
+    def wrapper(x):
+        # If the user passes a raw number, wrap it in a Term to maintain graph integrity.
+        if isinstance(x, Number):
+            x = Term(x)
+        # Generate the reactive node
+        formula = Formula(unary_op=func, _rhs=x)
+        # Bind the node to the parent to ensure signal propagation
+        x._parents.append(formula)
+        return formula
+    return wrapper
+
+# Expose standard trigonometric and algebraic functions
+acos = _reactive_unary(_math.acos)
+asin = _reactive_unary(_math.asin)
+atan = _reactive_unary(_math.atan)
+cos = _reactive_unary(_math.cos)
+sin = _reactive_unary(_math.sin)
+tan = _reactive_unary(_math.tan)
+exp = _reactive_unary(_math.exp)
+log = _reactive_unary(_math.log)
+log10 = _reactive_unary(_math.log10)
+sqrt = _reactive_unary(_math.sqrt)


### PR DESCRIPTION
## Description
Resolves #7.

Introduced `pypagate.math`, providing reactive wrappers for standard Python `math` operations.

## Architecture
- Created a `_reactive_unary` factory function that intercepts `math` methods. 
- The wrapper dynamically binds the operation to the reactive graph, appending the resulting `Formula` to the operand's `_parents` list to ensure proper signal propagation.
- Automatically converts raw `Number` primitives into `Term` objects if passed directly.
- **Engine Patch:** Rewrote `Formula.__str__` to directly access `globals()` and gracefully fall back to `__name__`. This bypasses Python's internal name mangling (`_Formula__unary_str_map`), patching a fatal `NameError` crash that previously occurred whenever printing a formula containing unrecognized external functions.