### PR TITLE
feat: Implement linear-time Bucket partitions for Universe queries

### DIFF
--- a/src/pypagate/__init__.py
+++ b/src/pypagate/__init__.py
@@ -473,6 +473,16 @@ def _specialize(law: Law | Variable, subs: tuple[Term, ...]):
 class Universe:
     entities: list[Term] = field(default_factory=list)
 
+@dataclass
+class Bucket:
+    """A linear-time spatial partition to restrict O(N^k) Law searches."""
+    universe: 'Universe'
+    condition: Callable[['Term'], bool]
+    
+    @property
+    def entities(self) -> list['Term']:
+        return [entity for entity in self.universe.entities if self.condition(entity)]
+    
 # Similar to here https://stackoverflow.com/a/7844038/667648
 def _law_register_bin_op(bin_op: Callable[[Any, Any], Any]):
     def b(self: Law | Variable, other: 'Law' | 'Variable' | 'Formula' | 'Term' | Number | Literal):
@@ -488,7 +498,7 @@ def _law_register_bin_op(bin_op: Callable[[Any, Any], Any]):
             vc = self._var_count
             vars_list = self.variables
         elif isinstance(other, Variable):
-            vc = self._var_count
+            vc = self._var_count + 1
             vars_list = self.variables + [other]
         else: # Law
             vc = getattr(self, '_var_count', 0) + getattr(other, '_var_count', 0)


### PR DESCRIPTION
### Overview
Resolves Issue #18 by introducing a `Bucket` class that acts as a spatial partition, restricting the $O(N^k)$ search space of a `Law` before the cross-product is generated.

### The Execution
Instead of modifying `Law` directly, `Bucket` takes a universe and a linear-time condition filter, impersonating a `Universe` via a dynamically evaluated `entities` property. Passing this `Bucket` into a `Variable` seamlessly filters the permutation generator without altering the core propagation loop. 

**Critical Patch Included:**
While stress-testing this, I discovered a fatal `IndexError` inside `_law_register_bin_op`. When evaluating `x > y`, the engine appended the new variable to `vars_list` but failed to increment `_var_count` (it used `vc = self._var_count` instead of `vc = self._var_count + 1`). This caused a dimension mismatch during `_specialize`. I have patched this in the same commit so the binary operators can safely handle multi-variable buckets.

Fixes #18